### PR TITLE
Fix two compiler warnings

### DIFF
--- a/libtap/src/tap.c
+++ b/libtap/src/tap.c
@@ -24,6 +24,7 @@
  * SUCH DAMAGE.
  */
 
+#define _GNU_SOURCE
 #include <ctype.h>
 #include <stdarg.h>
 #include <stdio.h>

--- a/libtap/src/tap.h
+++ b/libtap/src/tap.h
@@ -38,7 +38,7 @@
  *	plan_tests(13);
  */
 int plan_tests(unsigned int tests);
-static int plan(unsigned int tests)
+static inline int plan(unsigned int tests)
 {
     return plan_tests(tests);
 }


### PR DESCRIPTION
Fix this:

    /home/smarchi/src/libtap-prev/libtap/src/tap.c: In function ‘_gen_result’:
    /home/smarchi/src/libtap-prev/libtap/src/tap.c:87:7: error: implicit declaration of function ‘vasprintf’; did you mean ‘vsprintf’? [-Werror=implicit-function-declaration]
       if (vasprintf(&local_test_name, test_name, ap) < 0)
           ^~~~~~~~~
           vsprintf

by defining the GNU_SOURCE macro, as described in vasprintf's man page.

Fix this:

    /home/smarchi/src/libtap-prev/libtap/src/tap.h:41:12: error: ‘plan’ defined but not used [-Werror=unused-function]
     static int plan(unsigned int tests)
                ^~~~

by marking the function inline.  At least for gcc, adding "inline" makes
it not warn about unused static functions in header files.